### PR TITLE
Define the default value of the return value when the query doesn't match in jsonpath function

### DIFF
--- a/_examples/.policy/test.hcl
+++ b/_examples/.policy/test.hcl
@@ -1,12 +1,33 @@
-rule "test" {
-  description = "Test"
+rule "replicas" {
+  description = ""
 
-  expressions = [true]
+  ignore_cases = [
+    "${jsonpath("kind") != "Deployment"}",
+  ]
+
+  expressions = [
+    "${jsonpath("spec.replicas", 0) >= 1}",
+  ]
 
   report {
     level   = "ERROR"
-    message = "${color("red", "red")}"
+    message = "Too few replicas"
   }
+}
 
-  debug = []
+rule "images" {
+  description = ""
+
+  ignore_cases = [
+    "${jsonpath("kind") != "Deployment"}",
+  ]
+
+  expressions = [
+    "${jsonpath("spec.template.spec.containers.#.name") != ""}",
+  ]
+
+  report {
+    level   = "ERROR"
+    message = "hoge"
+  }
 }

--- a/docs/syntax/interpolation.md
+++ b/docs/syntax/interpolation.md
@@ -256,6 +256,10 @@ Usage:
 # => "\x1b[31m\x1b[40mhello!\x1b[0m"
 ```
 
+### `jsonpath(query, default...)`
+
+WIP
+
 ## Custom Functions
 
 While supporting some useful built-in functions, Stein allows to create user-defined functions.

--- a/lang/rule.go
+++ b/lang/rule.go
@@ -32,6 +32,22 @@ func decodeRuleBlock(block *hcl.Block) (*Rule, hcl.Diagnostics) {
 		})
 	}
 
+	// TODO: Depends on jsonpath's default value
+	//   By introducing the default value concept into jsonpath func,
+	//   it became not to need to take care of this
+	//   if jsonpath doesn't have default value, this case will be failed sometimes
+	//   e.g. "${jsonpath("spec.replicas") > 0}"
+	//   if kind is Service, jsonpath("spec.replicas") returns ""
+	//   so this expression will be "${"" > 0}" as a result
+	//   This is the reason why needs default value for jsonpath
+	//   Otherwise, operate the LHS which is dependent on RHS in hcl2 library
+	//
+	//   See also
+	//   https://github.com/hashicorp/hcl2/blob/cce5ae6cc5c890122f922573d6bf973eef0509f7/hcl/hclsyntax/expression_ops.go#L123-L196
+	//
+	// if attr, exists := content.Attributes["expressions"]; exists {
+	// }
+
 	if attr, exists := content.Attributes["depends_on"]; exists {
 		val, valDiags := attr.Expr.Value(nil)
 		diags = append(diags, valDiags...)

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -194,6 +194,7 @@ func (l *Linter) Run(file File) (Result, error) {
 		if rule.getStatus() != Success {
 			result.OK = false
 		}
+
 		for _, debug := range rule.Debugs {
 			pp.Println(debug)
 		}


### PR DESCRIPTION
## WHAT

Make it possible to define the default value of the return value when the query doesn't match in `jsonpath` function.

| Before | After |
|---|---|
|`jsonpath(query)`|`jsonpath(query, [default])`|

- `query`: String
- `default` (optional): Any
  - if it's omitted, default value will be handled as string. it means `""`

## WHY

The expressions with using `jsonpath` function fails sometimes when facing the value except for string. Let me see the concrete scene.

```console
$ export STEIN_POLICY=_examples/.policy,_examples/manifests/.policy/
$ ./stein apply _examples/manifests/microservices/*/*/*/*
```

_examples/manifests/microservices/x-echo-jp/development/Service/service.yaml:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: service
  namespace: xxx
  labels:
    app: redis
    tier: backend
    role: master
spec:
  ports:
  - port: 6379
    targetPort: 6379
  selector:
    app: redis
    tier: backend
    role: master
```

_examples/.policy/rules.hcl

```hcl
rule "replicas" {
  description = "Check the number of replicas"

  // Skip if kind is not Deployment. e.g. Service
  ignore_cases = [
    "${jsonpath("kind") != "Deployment"}",
  ]

  expressions = [
    "${jsonpath("spec.replicas") >= 1}",
  ]

  report {
    level   = "ERROR"
    message = "Too few replicas"
  }
}
```

In this case, `jsonpath("spec.replicas")` will be `""` when loading the file that its kind type is Service etc. Due to that, this expressions will be the following as a result:

```hcl
  expressions = [
    "${"" >= 1}",
  ]
```

This is unexpected behavior. So I'd like to take the default value in `jsonpath` function.

By doing the following,

```hcl
  expressions = [
    "${jsonpath("spec.replicas", 0) >= 1}",
  ]
```

`jsonpath` will return `0` instead of `""` even if the query of `spec.replicas` doesn't match. Thanks to that, this expressions will be correct evaluation.

```hcl
  expressions = [
    "${0 >= 1}",
  ]
```

## Notes

There is an alternative plan.

`lang/rule.go`:

```go
	// if attr, exists := content.Attributes["expressions"]; exists {
	// }
```

That is a way of automatically determining the type to be returned. If it does not match the query, it can be this alternative by making the type of return value the type of the right side to be evaluated. It can be `lang/rule.go` file.

However, interface interface interface. It might not be able to handle the value of expressions. If so, I have to touch this in hcl2 package directly. See also,

https://github.com/hashicorp/hcl2/blob/cce5ae6cc5c890122f922573d6bf973eef0509f7/hcl/hclsyntax/expression_ops.go#L123-L196
