### PR TITLE
Add precondition block and leave out ignore_cases conditions

### DIFF
--- a/_examples/.policy/functions.hcl
+++ b/_examples/.policy/functions.hcl
@@ -12,3 +12,8 @@ function "is_irregular_namespace_pattern" {
   params = []
   result = contains(var.special_cases, get_service_id_with_env(filename))
 }
+
+function "kind" {
+  params = [name]
+  result = jsonpath("kind") == title(name)
+}

--- a/_examples/.policy/rules.hcl
+++ b/_examples/.policy/rules.hcl
@@ -1,8 +1,6 @@
 rule "namespace_specification" {
   description = "Check namespace name is not empty"
 
-  ignore_cases = []
-
   expressions = [
     "${jsonpath("metadata.namespace") != ""}",
   ]
@@ -18,9 +16,11 @@ rule "namespace_name" {
 
   depends_on = ["rule.namespace_specification"]
 
-  ignore_cases = [
-    "${is_irregular_namespace_pattern()}",
-  ]
+  precondition {
+    cases = [
+      "${!is_irregular_namespace_pattern()}",
+    ]
+  }
 
   expressions = [
     "${jsonpath("metadata.namespace") == get_service_id_with_env(filename)}",
@@ -37,9 +37,11 @@ rule "namespace_name_irregular" {
 
   depends_on = ["rule.namespace_specification"]
 
-  ignore_cases = [
-    "${!is_irregular_namespace_pattern()}",
-  ]
+  precondition {
+    cases = [
+      "${is_irregular_namespace_pattern()}",
+    ]
+  }
 
   expressions = [
     "${contains(lookuplist(var.namespace_name_map, jsonpath("metadata.namespace")), get_service_id_with_env(filename))}",
@@ -47,14 +49,12 @@ rule "namespace_name_irregular" {
 
   report {
     level   = "ERROR"
-    message = "${format("Namespace name %q is invalid", jsonpath("metadata.namespace"))}"
+    message = "${format("This case is irregular pattern, so %q is invalid", jsonpath("metadata.namespace"))}"
   }
 }
 
 rule "extension" {
-  description = "Acceptable yaml file extensions are limtited"
-
-  ignore_cases = []
+  description = "Acceptable yaml file extensions are limited"
 
   expressions = [
     "${ext(filename) == ".yaml" || ext(filename) == ".yaml.enc"}",

--- a/_examples/.policy/test.hcl
+++ b/_examples/.policy/test.hcl
@@ -1,9 +1,9 @@
 rule "replicas" {
   description = ""
 
-  ignore_cases = [
-    "${jsonpath("kind") != "Deployment"}",
-  ]
+  precondition {
+    cases = ["${kind("Deployment")}"]
+  }
 
   expressions = [
     "${jsonpath("spec.replicas", 0) >= 1}",
@@ -18,9 +18,9 @@ rule "replicas" {
 rule "images" {
   description = ""
 
-  ignore_cases = [
-    "${jsonpath("kind") != "Deployment"}",
-  ]
+  precondition {
+    cases = ["${kind("Deployment")}"]
+  }
 
   expressions = [
     "${jsonpath("spec.template.spec.containers.#.name") != ""}",

--- a/_examples/manifests/.policy/rules.hcl
+++ b/_examples/manifests/.policy/rules.hcl
@@ -1,8 +1,6 @@
 rule "filename" {
   description = "Check filename is the same as metadata.name"
 
-  ignore_cases = []
-
   expressions = [
     "${jsonpath("metadata.name") == remove_ext(filename)}",
   ]
@@ -16,8 +14,6 @@ rule "filename" {
 rule "resource_per_file" {
   description = ""
 
-  ignore_cases = []
-
   expressions = [
     "${wc(grep("^kind: ", file(filename))) == 0}",
   ]
@@ -30,8 +26,6 @@ rule "resource_per_file" {
 
 rule "yaml_separator" {
   description = "Do not use YAML separator"
-
-  ignore_cases = []
 
   expressions = [
     "${length(grep("^---", file(filename))) == 0}",

--- a/docs/policy/rules.md
+++ b/docs/policy/rules.md
@@ -35,7 +35,8 @@ There are **meta-parameters** available to all rules:
 
 - `description` (string) - A human-friendly description for the rule. This is primarily for documentation for users using your Stein configuration. When a module is published in Terraform Registry, the given description is shown as part of the documentation.
 - `depends_on` (list of strings) - Other rules which this rule depends on. This rule will be skipped if the dependency rules has failed. The rule name which will be described in "depends_on" list should follow as "rule.xxx".
-- `ignore_cases` (list of bools) - Conditions to ignore execution of the rule. If it contains one or more True condition, this rule will be skipped.
+- `precondition` (configuration block; optional) -
+    - `cases` (list of bools) - Conditions to determine whether the rule should be executed. This rule will only be executed if all preconditions return true.
 - `expressions` (list of bools) - Conditions for deciding whether this rule passes or fails. In order to pass, all conditions must return True.
 - `report` (configuration block) -
     - `level` (string) - Error level. It can take "ERROR" or "WARN" as the level. In case of "ERROR", this rule fails. But in case of "WARN", this rule doesn't fail.
@@ -49,14 +50,29 @@ The full syntax is:
 rule NAME {
   description = DESCRIPTION
 
-  [depends_on = [rule, rule, ...]]
-  [ignore_cases = [bool, bool, ...]]
+  [depends_on = [NAME, ...]]
 
-  expressions = [bool, bool, ...]
+  [PRECONDITION]
 
-  report {
-    level = [ERROR|WARN]
-    message = MESSAGE
-  }
+  expressions = [CONDITION, ...]
+
+  REPORT
+}
+```
+
+where PRECONDITION is:
+
+```hcl
+precondition {
+  cases = [CONDITION, ...]
+}
+```
+
+where REPORT is:
+
+```hcl
+report {
+  level = [ERROR|WARN]
+  message = MESSAGE
 }
 ```

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -383,10 +383,14 @@ func (l *Linter) PrintSummary(results ...Result) {
 	fmt.Fprintln(l.stderr, result)
 }
 
-// SkipCase returns true if there is even one IgnoreCases.
+// SkipCase returns true if cases of a precondition block includes one or more failed cases
 func (r *Rule) SkipCase() bool {
-	for _, ignore := range r.IgnoreCases {
-		if ignore {
+	// don't skip if a precondition block is not specified
+	if r.Precondition == nil {
+		return false
+	}
+	for _, ok := range r.Precondition.Cases {
+		if !ok {
 			return true
 		}
 	}

--- a/lint/policy.go
+++ b/lint/policy.go
@@ -33,11 +33,11 @@ type ReportConfig struct {
 type Rule struct {
 	Name string `hcl:"name,label"`
 
-	Description  string   `hcl:"description"`
-	Dependencies []string `hcl:"depends_on,optional"`
-	IgnoreCases  []bool   `hcl:"ignore_cases,optional"`
-	Expressions  []bool   `hcl:"expressions"`
-	Report       Report   `hcl:"report,block"`
+	Description  string        `hcl:"description"`
+	Dependencies []string      `hcl:"depends_on,optional"`
+	Precondition *Precondition `hcl:"precondition,block"`
+	Expressions  []bool        `hcl:"expressions"`
+	Report       Report        `hcl:"report,block"`
 
 	Debugs []string `hcl:"debug,optional"`
 }
@@ -54,6 +54,11 @@ type Report struct {
 
 	// Message is shown when the rule is failed
 	Message string `hcl:"message"`
+}
+
+// Precondition represents a condition that determines whether the rule should be executed
+type Precondition struct {
+	Cases []bool `hcl:"cases"`
 }
 
 // Output is WIP


### PR DESCRIPTION
## WHAT

Add `precondition` block to determine whether the rule should be executed or not. Instead of that, `ignore_cases` will be left out.

Let's think about a concrete situation,

*Situation: In Kubernetes YAML, execute a rule only if `kind` is Service*

**Before**

```hcl
rule "xxx" {
  ignore_cases = ["${jsonpath("kind") != "Service"}]
}
```

**After**

```hcl
rule "xxx" {
  precondition {
    cases = ["${jsonpath("kind") == "Service"}]
  }
}
```

Prerequisites became more intuitive than before.

## WHY

`ignore_cases` has a negative meaning while `precondition` has a positive one. So it's more intuitive. 