### PR TITLE
Add log mechanism for debugging like Terraform

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,6 +101,16 @@ service.yaml
 
 For more details about this behavior, see also [How policies are loaded by `stein` - Policy](policy.md#how-policies-are-loaded-by-stein).
 
+## Debug stein
+
+Stein has detailed logs which can be enabled by setting the `STEIN_LOG` environment variable to any value. This will cause detailed logs to appear on stderr.
+
+You can set `STEIN_LOG` to one of the log levels `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR` to change the verbosity of the logs. `TRACE` is the most verbose and it is the default if `STEIN_LOG` is set to something other than a log level name.
+
+To persist logged output you can set `STEIN_LOG_PATH` in order to force the log to always be appended to a specific file when logging is enabled. Note that even when `STEIN_LOG_PATH` is set, `STEIN_LOG` must be set in order for any logging to be enabled.
+
+If you find a bug with Stein, please include the detailed log by using a service such as gist.
+
 ## What's next
 
 - [Writing Policy](writing-policy.md)

--- a/lint/args.go
+++ b/lint/args.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -32,9 +33,13 @@ type File struct {
 
 // filesFromArgs converts from given arguments to the collection of File object
 func filesFromArgs(args []string, additionals ...string) (files []File, err error) {
+	log.Printf("[TRACE] converting from args to lint.Files\n")
 	for _, arg := range args {
+		log.Printf("[INFO] converting lint.File: %s\n", arg)
 		policies := loader.SearchPolicyDir(arg)
 		policies = append(policies, additionals...)
+		log.Printf("[INFO] policies: %#v\n", policies)
+
 		loadedPolicy, err := loader.Load(policies...)
 		if err != nil {
 			return files, err
@@ -52,6 +57,7 @@ func filesFromArgs(args []string, additionals ...string) (files []File, err erro
 			if err != nil {
 				return files, err
 			}
+			log.Printf("[TRACE] %d block(s) found in YAML: %s\n", len(yamlFiles), arg)
 			for _, file := range yamlFiles {
 				file.Policy = loadedPolicy
 				files = append(files, file)

--- a/lint/internal/policy/policy.go
+++ b/lint/internal/policy/policy.go
@@ -52,7 +52,6 @@ var policySchema = &hcl.BodySchema{
 // Decode is
 func Decode(body hcl.Body) (*Policy, hcl.Diagnostics) {
 	policy := &Policy{}
-	// Files: files,
 	content, diags := body.Content(policySchema)
 
 	for _, block := range content.Blocks {

--- a/main.go
+++ b/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
+	"runtime"
 
+	"github.com/b4b4r07/stein/pkg/logging"
 	"github.com/mitchellh/cli"
 )
 
@@ -24,6 +27,16 @@ type CLI struct {
 }
 
 func main() {
+	logWriter, err := logging.LogOutput()
+	if err != nil {
+		panic(err)
+	}
+	log.SetOutput(logWriter)
+
+	log.Printf("[INFO] Stein version: %s", Version)
+	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
+	log.Printf("[INFO] CLI args: %#v", os.Args)
+
 	stein := CLI{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,128 @@
+package logging
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/logutils"
+)
+
+// These are the environmental variables that determine if we log, and if
+// we log whether or not the log should go to a file.
+const (
+	EnvLog     = "STEIN_LOG"
+	EnvLogFile = "STEIN_LOG_PATH"
+)
+
+// ValidLevels is a list of valid log levels
+var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+
+// LogOutput determines where we should send logs (if anywhere) and the log level.
+func LogOutput() (logOutput io.Writer, err error) {
+	logOutput = ioutil.Discard
+
+	logLevel := LogLevel()
+	if logLevel == "" {
+		return
+	}
+
+	logOutput = os.Stderr
+	if logPath := os.Getenv(EnvLogFile); logPath != "" {
+		var err error
+		logOutput, err = os.OpenFile(logPath, syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// This was the default since the beginning
+	logOutput = &logutils.LevelFilter{
+		Levels:   ValidLevels,
+		MinLevel: logutils.LogLevel(logLevel),
+		Writer:   logOutput,
+	}
+
+	return
+}
+
+// SetOutput checks for a log destination with LogOutput, and calls
+// log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
+// ioutil.Discard. Any error from LogOutout is fatal.
+func SetOutput() {
+	out, err := LogOutput()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if out == nil {
+		out = ioutil.Discard
+	}
+
+	log.SetOutput(out)
+}
+
+// LogLevel returns the current log level string based the environment vars
+func LogLevel() string {
+	envLevel := os.Getenv(EnvLog)
+	if envLevel == "" {
+		return ""
+	}
+
+	logLevel := "TRACE"
+	if isValidLogLevel(envLevel) {
+		// allow following for better ux: info, Info or INFO
+		logLevel = strings.ToUpper(envLevel)
+	} else {
+		log.Printf("[WARN] Invalid log level: %q. Defaulting to level: TRACE. Valid levels are: %+v",
+			envLevel, ValidLevels)
+	}
+
+	return logLevel
+}
+
+// IsDebugOrHigher returns whether or not the current log level is debug or trace
+func IsDebugOrHigher() bool {
+	level := string(LogLevel())
+	return level == "DEBUG" || level == "TRACE"
+}
+
+func isValidLogLevel(level string) bool {
+	for _, l := range ValidLevels {
+		if strings.ToUpper(level) == string(l) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Call outputs logs with function name
+func Call(format string, a ...interface{}) {
+	count, _, _, _ := runtime.Caller(1)
+	fn := runtime.FuncForPC(count)
+	// fileName, fileLine := fn.FileLine(count)
+	// log.Printf("[DEBUG] %s (%s:%d) | %v", fn.Name(), fileName, fileLine, fmt.Sprintf(format, a...))
+	log.Printf("%s | %v", fn.Name(), fmt.Sprintf(format, a...))
+}
+
+// Dump returns detailed format string
+func Dump(a ...interface{}) string {
+	cfg := &spew.ConfigState{
+		ContinueOnMethod:        true,
+		DisableCapacities:       true,
+		DisableMethods:          true,
+		DisablePointerAddresses: true,
+		DisablePointerMethods:   true,
+		Indent:                  "  ",
+		MaxDepth:                3,
+		SortKeys:                false,
+	}
+	return cfg.Sdump(a)
+}


### PR DESCRIPTION
## WHAT

Add logging feature like Terraform one.

- `STEIN_LOG`: Set log level
- `STEIN_LOG_PATH`: Set path to log file if STEIN_LOG is set

## WHY

Stein has a lot of feature and does many things in its internal. It'll be useful for developers and users by visualizing these processes.
