### PR TITLE
Add simple test cases for lint.filesFromArgs

### DIFF
--- a/lint/args_test.go
+++ b/lint/args_test.go
@@ -1,0 +1,114 @@
+package lint
+
+import (
+	"testing"
+)
+
+func Test_filesFromArgs(t *testing.T) {
+	tests := []struct {
+		Filename string
+		Want     string
+	}{
+		{
+			"testdata/01.tf",
+			`{
+  "provider": [
+    {
+      "google": [
+        {
+          "project": "my-project-id",
+          "region": "us-central1"
+        }
+      ]
+    }
+  ]
+}`,
+		},
+		{
+			"testdata/02.tf",
+			`{
+  "provider": [
+    {
+      "google": [
+        {
+          "project": "my-project-id",
+          "region": "us-central1"
+        }
+      ]
+    },
+    {
+      "aws": [
+        {
+          "region": "us-east-1",
+          "version": "~\u003e 2.0"
+        }
+      ]
+    },
+    {
+      "google": [
+        {
+          "alias": "west",
+          "project": "my-project-id",
+          "region": "us-west1"
+        }
+      ]
+    }
+  ]
+}`,
+		},
+		{
+			"testdata/03.tf",
+			`{
+  "module": [
+    {
+      "foo": [
+        {
+          "array": [
+            "val1",
+            "val2"
+          ],
+          "bar": "baz"
+        }
+      ]
+    }
+  ]
+}`,
+		},
+		{
+			"testdata/04.tf",
+			`{
+  "resource": [
+    {
+      "google_project": [
+        {
+          "my_project": [
+            {
+              "name": "My Project",
+              "org_id": "1234567",
+              "project_id": "your-project-id"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Filename, func(t *testing.T) {
+			files, err := filesFromArgs([]string{test.Filename})
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if len(files) != 1 {
+				t.Errorf("unexpected files length: got %d, want 1", len(files))
+			}
+			got := string(files[0].Data)
+			if got != test.Want {
+				t.Errorf("wrong result: got: %#v, want: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/lint/testdata/01.tf
+++ b/lint/testdata/01.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}

--- a/lint/testdata/02.tf
+++ b/lint/testdata/02.tf
@@ -1,0 +1,13 @@
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+provider "google" {
+  project = "my-project-id"
+  region  = "us-west1"
+  alias   = "west"
+}

--- a/lint/testdata/03.tf
+++ b/lint/testdata/03.tf
@@ -1,0 +1,8 @@
+module "foo" {
+  bar = "baz"
+
+  array = [
+    "val1",
+    "val2",
+  ]
+}

--- a/lint/testdata/04.tf
+++ b/lint/testdata/04.tf
@@ -1,0 +1,6 @@
+resource "google_project" "my_project" {
+  name       = "My Project"
+  project_id = "your-project-id"
+  org_id     = "1234567"
+}
+


### PR DESCRIPTION
## WHAT

This pull request adds simple test cases for `lint.filesFromArgs`.

## WHY

To make sure the JSON structure created by https://github.com/b4b4r07/stein/pull/18 is as same as before.